### PR TITLE
Correct who can add group events on curated calendars

### DIFF
--- a/docs/b1-admin/calendars/creating-calendars.md
+++ b/docs/b1-admin/calendars/creating-calendars.md
@@ -6,7 +6,7 @@ title: "Creating Calendars"
 
 <div class="article-intro">
 
-Creating a calendar in B1 Admin lets you build a curated view of events by connecting one or more groups. Events are managed by group leaders within their groups, and your calendar displays those events in one place. Even a domain admin cannot add or edit events directly in the calendar section unless they are a leader of the group the events belong to.
+Creating a calendar in B1 Admin lets you build a curated view of events by connecting one or more groups. Events are managed by group leaders within their groups, and your calendar displays those events in one place. Admins with edit access can add or edit events for any group. Non-admin group leaders can only manage events for groups they lead.
 
 </div>
 


### PR DESCRIPTION
The creating-calendars doc said even a domain admin could not add events unless they led the group. Admins with content.edit or calendars.admin can add events for any group; only non-admin leaders are limited to groups they lead.

https://github.com/ChurchApps/ChurchAppsSupport/issues/1036